### PR TITLE
refactor(startup): migrate index to ESM & modular BotClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ out/
 src/config.json
 src/database
 IP.md
+config.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,230 @@
+# Discord Bot - モジュール構造版
+
+TypeScript で実装された Discord Bot のモジュール化されたプロジェクトです。スラッシュコマンドと JSON ベースのデータベースシステムを使用しています。
+
+## 📁 プロジェクト構造
+
+```
+Discordbot/
+├── src/
+│   ├── index.ts                # エントリポイント
+│   ├── core/                   # コアモジュール
+│   │   ├── BotClient.ts       # Discord クライアント管理
+│   │   ├── EventHandler.ts    # イベント処理
+│   │   ├── CommandLoader.ts   # コマンド自動読み込み
+│   │   └── Database.ts        # JSON データベース
+│   ├── commands/               # スラッシュコマンド
+│   │   ├── utility/           # ユーティリティコマンド
+│   │   │   ├── ping.ts        # Ping コマンド
+│   │   │   └── info.ts        # Bot 情報コマンド
+│   │   └── admin/             # 管理者コマンド
+│   │       └── database.ts    # データベース操作コマンド
+│   ├── utils/                  # ユーティリティ
+│   │   ├── Logger.ts          # ロガー
+│   │   ├── PermissionChecker.ts # 権限チェック
+│   │   └── CooldownManager.ts # クールダウン管理
+│   └── types/                  # 型定義
+│       └── command.ts         # コマンドの型
+├── Data/                       # データベースフォルダ（自動生成）
+├── config.json                 # Bot 設定ファイル
+├── config.example.json         # 設定ファイルのサンプル
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+## 🚀 セットアップ
+
+### 1. 依存関係のインストール
+
+```bash
+bun install
+# または
+npm install
+```
+
+### 2. 設定ファイルの作成
+
+`config.example.json` をコピーして `config.json` を作成し、Bot トークンを入力してください。
+
+```json
+{
+  "token": "YOUR_BOT_TOKEN_HERE"
+}
+```
+
+**必要な設定はトークンのみです！**
+- ~~clientId~~ → 不要（自動取得）
+- ~~guildId~~ → 不要（全サーバー自動対応）
+- ~~deployGlobal~~ → 不要（自動デプロイ）
+
+### 3. Bot の起動
+
+```bash
+# 開発環境
+bun run src/index.ts
+
+# ビルド（本番環境用バイナリ）
+bun run auto           # 全プラットフォーム
+bun run windows-64     # Windows x64
+```
+
+## 🎯 機能
+
+### ✅ 実装済み機能
+
+- **簡単セットアップ**: トークンのみで起動可能
+- **自動デプロイ**: 全サーバーに自動的にコマンドをデプロイ
+- **サーバー上限管理**: 最大50サーバーまで対応
+  - 上限超過時は自動退出
+  - オーナーにDM通知
+- **モジュール構造**: Core、Commands、Utils に分離された設計
+- **スラッシュコマンド**: Discord.js v14 の ApplicationCommand に対応
+- **4段階権限システム**: ANY / STAFF / ADMIN / OP
+- **自動コマンド読み込み**: `src/commands/` 配下のコマンドを自動検出
+- **JSON データベース**: `Data/` フォルダに JSON ファイルとして保存
+- **イベントハンドリング**: Discord イベントの集中管理
+- **ロガー**: 色付きコンソールログ
+- **権限チェック**: 管理者・モデレーター権限の確認
+- **クールダウン管理**: コマンドの連続実行制限
+
+### 📦 標準コマンド
+
+| コマンド | 説明 | 権限 |
+|---------|------|------|
+| `/ping [detailed]` | Bot の応答速度を確認 | ANY |
+| `/info` | Bot の詳細情報を表示 | ANY |
+| `/userinfo [user]` | ユーザー情報を表示 | ANY |
+| `/servers` | Bot が参加しているサーバー一覧 | OP |
+| `/db set <key> <value>` | データベースに保存 | ANY |
+| `/db get <key>` | データベースから取得 | ANY |
+| `/db delete <key>` | データベースから削除 | ANY |
+| `/db list` | すべてのキーを表示 | ANY |
+
+## ⚙️ サーバー上限機能
+
+Bot は**最大50サーバー**までサポートします。
+
+### 動作:
+1. **50サーバー以下**: 通常通り動作
+2. **51サーバー目を追加**: 
+   - サーバーオーナーにDM通知
+   - 自動的にそのサーバーから退出
+   - ログに記録
+
+### ログ例:
+```
+📥 新しいサーバーに参加: Example Server (ID: 123456789)
+📊 現在のサーバー数: 51/50
+⚠️ サーバー上限 (50) を超えました。サーバーから退出します: Example Server
+✅ サーバーから退出しました: Example Server
+```
+
+## 🛠️ 新しいコマンドの追加方法
+
+### 1. コマンドファイルを作成
+
+`src/commands/` 配下に新しい `.ts` ファイルを作成します。
+
+```typescript
+// src/commands/example/hello.ts
+import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { SlashCommand } from '../../types/command.js';
+
+export const command: SlashCommand = {
+    data: new SlashCommandBuilder()
+        .setName('hello')
+        .setDescription('挨拶します')
+        .addStringOption(option =>
+            option.setName('name')
+                .setDescription('名前')
+                .setRequired(true)
+        ),
+
+    async execute(interaction: ChatInputCommandInteraction) {
+        const name = interaction.options.getString('name', true);
+        await interaction.reply(`こんにちは、${name}さん！`);
+    }
+};
+
+export default command;
+```
+
+### 2. Bot を再起動
+
+コマンドローダーが自動的に新しいコマンドを検出して登録します。
+
+## 💾 データベースの使い方
+
+```typescript
+import { database } from './core/Database.js';
+
+// データを保存
+await database.set('myKey', { foo: 'bar', count: 42 });
+
+// データを取得
+const data = await database.get('myKey');
+
+// データの存在確認
+const exists = await database.has('myKey');
+
+// データを削除
+await database.delete('myKey');
+
+// すべてのキーを取得
+const keys = await database.keys();
+```
+
+データは `Data/` フォルダに JSON ファイルとして保存されます。
+
+## 🔧 開発ガイド
+
+### Core モジュール
+
+- **BotClient**: Discord クライアントの初期化とコマンド管理
+- **EventHandler**: Discord イベントのリスナー登録
+- **CommandLoader**: コマンドの自動読み込みと登録
+- **Database**: JSON ベースのデータ永続化
+
+### Utils モジュール
+
+- **Logger**: カラフルなコンソールログ出力
+- **PermissionChecker**: ユーザー権限の確認
+- **CooldownManager**: コマンドのクールダウン制御
+
+### 型定義
+
+- **Command**: レガシーメッセージコマンド（後方互換性）
+- **SlashCommand**: スラッシュコマンドの型定義
+
+## 📝 注意事項
+
+- `config.json` には Bot トークンが含まれます。**絶対に公開しないでください**
+- `.gitignore` に `config.json` と `Data/` フォルダが追加されています
+- 開発時は `guildId` を設定してギルド固有のコマンドとしてデプロイすることを推奨します（即座に反映されます）
+- グローバルコマンドは反映に最大1時間かかる場合があります
+
+## 🐛 トラブルシューティング
+
+### コマンドが表示されない
+
+1. `config.json` の `clientId` が正しいか確認
+2. Bot に `applications.commands` スコープが付与されているか確認
+3. ギルドにコマンドをデプロイする場合は `guildId` を設定
+
+### データベースエラー
+
+1. `Data/` フォルダの書き込み権限を確認
+2. JSON ファイルが破損していないか確認
+
+## 📄 ライセンス
+
+MIT
+
+## 👤 作者
+
+Koukunn_
+
+## 🔗 リンク
+
+- [GitHub Repository](https://github.com/gamelist1990/PEXclient)

--- a/src/commands/admin/database.ts
+++ b/src/commands/admin/database.ts
@@ -1,0 +1,131 @@
+import { PermissionLevel, DynamicCommandOptions, CommandBuilderCallback } from '../../types/enhanced-command.js';
+import { ChatInputCommandInteraction, EmbedBuilder, SlashCommandBuilder } from 'discord.js';
+import { database } from '../../core/Database.js';
+
+const command: DynamicCommandOptions = {
+    name: 'db',
+    description: 'データベース操作のテストコマンド',
+    permissionLevel: PermissionLevel.OP,
+    
+    builder: ((eb: SlashCommandBuilder) => {
+        return eb
+            .addSubcommand(subcommand =>
+                subcommand
+                    .setName('set')
+                    .setDescription('データを保存します')
+                    .addStringOption(option =>
+                        option.setName('key')
+                            .setDescription('保存するキー')
+                            .setRequired(true))
+                    .addStringOption(option =>
+                        option.setName('value')
+                            .setDescription('保存する値')
+                            .setRequired(true))
+            )
+            .addSubcommand(subcommand =>
+                subcommand
+                    .setName('get')
+                    .setDescription('データを取得します')
+                    .addStringOption(option =>
+                        option.setName('key')
+                            .setDescription('取得するキー')
+                            .setRequired(true))
+            )
+            .addSubcommand(subcommand =>
+                subcommand
+                    .setName('delete')
+                    .setDescription('データを削除します')
+                    .addStringOption(option =>
+                        option.setName('key')
+                            .setDescription('削除するキー')
+                            .setRequired(true))
+            )
+            .addSubcommand(subcommand =>
+                subcommand
+                    .setName('list')
+                    .setDescription('すべてのキーを表示します')
+            );
+    }) as CommandBuilderCallback,
+
+    async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+        const subcommand = interaction.options.getSubcommand();
+
+        try {
+            switch (subcommand) {
+                case 'set': {
+                    const key = interaction.options.getString('key', true);
+                    const value = interaction.options.getString('value', true);
+                    
+                    await database.set(key, { value, savedAt: new Date().toISOString(), savedBy: interaction.user.id });
+                    
+                    const embed = new EmbedBuilder()
+                        .setColor('#00ff00')
+                        .setTitle('✅ データを保存しました')
+                        .addFields(
+                            { name: 'キー', value: key, inline: true },
+                            { name: '値', value: value, inline: true }
+                        )
+                        .setTimestamp();
+                    
+                    await interaction.reply({ embeds: [embed] });
+                    break;
+                }
+
+                case 'get': {
+                    const key = interaction.options.getString('key', true);
+                    const data = await database.get(key);
+
+                    if (!data) {
+                        await interaction.reply({ content: `❌ キー \`${key}\` は存在しません。`, ephemeral: true });
+                        return;
+                    }
+
+                    const embed = new EmbedBuilder()
+                        .setColor('#0099ff')
+                        .setTitle('📦 データ取得')
+                        .addFields(
+                            { name: 'キー', value: key, inline: false },
+                            { name: '値', value: JSON.stringify(data, null, 2), inline: false }
+                        )
+                        .setTimestamp();
+
+                    await interaction.reply({ embeds: [embed] });
+                    break;
+                }
+
+                case 'delete': {
+                    const key = interaction.options.getString('key', true);
+                    await database.delete(key);
+
+                    const embed = new EmbedBuilder()
+                        .setColor('#ff0000')
+                        .setTitle('🗑️ データを削除しました')
+                        .addFields({ name: 'キー', value: key })
+                        .setTimestamp();
+
+                    await interaction.reply({ embeds: [embed] });
+                    break;
+                }
+
+                case 'list': {
+                    const keys = await database.keys();
+
+                    const embed = new EmbedBuilder()
+                        .setColor('#ffff00')
+                        .setTitle('📋 データベースキー一覧')
+                        .setDescription(keys.length > 0 ? keys.map(k => `\`${k}\``).join(', ') : '保存されているデータはありません')
+                        .setFooter({ text: `合計: ${keys.length} 個` })
+                        .setTimestamp();
+
+                    await interaction.reply({ embeds: [embed] });
+                    break;
+                }
+            }
+        } catch (error) {
+            console.error('データベース操作エラー:', error);
+            await interaction.reply({ content: '❌ データベース操作中にエラーが発生しました。', ephemeral: true });
+        }
+    }
+};
+
+export default command;

--- a/src/commands/admin/servers.ts
+++ b/src/commands/admin/servers.ts
@@ -1,0 +1,45 @@
+import { PermissionLevel, DynamicCommandOptions } from '../../types/enhanced-command.js';
+import { ChatInputCommandInteraction, EmbedBuilder, Client, Guild } from 'discord.js';
+
+const MAX_GUILDS = 50;
+
+const command: DynamicCommandOptions = {
+    name: 'servers',
+    description: 'Bot が参加しているサーバー一覧を表示します',
+    permissionLevel: PermissionLevel.OP,
+    
+    async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+        const client: Client = interaction.client;
+        const guilds: Guild[] = Array.from(client.guilds.cache.values());
+
+        // サーバーリストを作成
+        const guildList = guilds
+            .sort((a: Guild, b: Guild) => b.memberCount - a.memberCount)
+            .map((guild: Guild, index: number) => {
+                return `${index + 1}. **${guild.name}** (${guild.memberCount.toLocaleString()} メンバー)`;
+            })
+            .join('\n');
+
+        const totalMembers = guilds.reduce((sum: number, g: Guild) => sum + g.memberCount, 0);
+
+        const embed = new EmbedBuilder()
+            .setColor(guilds.length >= MAX_GUILDS ? '#ff0000' : '#00ff00')
+            .setTitle('📊 サーバー一覧')
+            .setDescription(guildList || 'サーバーに参加していません')
+            .addFields(
+                { name: '現在のサーバー数', value: `${guilds.length}/${MAX_GUILDS}`, inline: true },
+                { name: '合計メンバー数', value: totalMembers.toLocaleString(), inline: true },
+                { name: '残り枠', value: `${Math.max(0, MAX_GUILDS - guilds.length)}`, inline: true }
+            )
+            .setFooter({ 
+                text: guilds.length >= MAX_GUILDS 
+                    ? '⚠️ サーバー上限に達しています' 
+                    : `あと ${MAX_GUILDS - guilds.length} サーバー追加できます` 
+            })
+            .setTimestamp();
+
+        await interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+};
+
+export default command;

--- a/src/commands/utility/help.ts
+++ b/src/commands/utility/help.ts
@@ -1,0 +1,120 @@
+import { PermissionLevel, DynamicCommandOptions, CommandBuilderCallback } from '../../types/enhanced-command.js';
+import { ChatInputCommandInteraction, EmbedBuilder, SlashCommandBuilder } from 'discord.js';
+import { CommandRegistry } from '../../core/CommandRegistry.js';
+import { SlashCommand } from '../../types/command.js';
+
+const COMMANDS_PER_PAGE = 5;
+
+const command: DynamicCommandOptions = {
+    name: 'help',
+    description: 'コマンド一覧を表示します',
+    permissionLevel: PermissionLevel.ANY,
+    
+    builder: ((eb: SlashCommandBuilder) => {
+        return eb.addIntegerOption(option =>
+            option
+                .setName('page')
+                .setDescription('表示するページ番号')
+                .setRequired(false)
+                .setMinValue(1)
+        );
+    }) as CommandBuilderCallback,
+    
+    async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+        const requestedPage = interaction.options.getInteger('page') ?? 1;
+        
+        // CommandRegistry からコマンド一覧を取得
+        const registry = CommandRegistry.getInstance();
+        const commands = Array.from(registry.getCommands().values());
+        
+        if (commands.length === 0) {
+            await interaction.reply({ 
+                content: '❌ 登録されているコマンドがありません。', 
+                ephemeral: true 
+            });
+            return;
+        }
+
+        // 権限レベルでグループ化
+        const groupedCommands: Record<PermissionLevel, SlashCommand[]> = {
+            [PermissionLevel.ANY]: [],
+            [PermissionLevel.STAFF]: [],
+            [PermissionLevel.ADMIN]: [],
+            [PermissionLevel.OP]: [],
+        };
+
+        commands.forEach(cmd => {
+            const level = cmd.permissionLevel || PermissionLevel.ANY;
+            groupedCommands[level].push(cmd);
+        });
+
+        // ページネーション用にフラット化
+        const sortedCommands: Array<{ cmd: SlashCommand, level: PermissionLevel }> = [];
+        
+        for (const [level, cmds] of Object.entries(groupedCommands)) {
+            cmds.forEach(cmd => {
+                sortedCommands.push({ cmd, level: level as PermissionLevel });
+            });
+        }
+
+        const totalPages = Math.ceil(sortedCommands.length / COMMANDS_PER_PAGE);
+        const page = Math.max(1, Math.min(requestedPage, totalPages));
+        const startIndex = (page - 1) * COMMANDS_PER_PAGE;
+        const endIndex = Math.min(startIndex + COMMANDS_PER_PAGE, sortedCommands.length);
+        const pageCommands = sortedCommands.slice(startIndex, endIndex);
+
+        // Embedを作成
+        const embed = new EmbedBuilder()
+            .setColor('#00aaff')
+            .setTitle('📚 コマンド一覧')
+            .setDescription(`全 ${sortedCommands.length} 個のコマンドが登録されています\nページ ${page}/${totalPages}`)
+            .setTimestamp()
+            .setFooter({ text: `/help <ページ番号> で他のページを表示` });
+
+        // 権限レベルの絵文字マッピング
+        const levelEmoji: Record<PermissionLevel, string> = {
+            [PermissionLevel.ANY]: '🌐',
+            [PermissionLevel.STAFF]: '👔',
+            [PermissionLevel.ADMIN]: '🛡️',
+            [PermissionLevel.OP]: '👑',
+        };
+
+        const levelName: Record<PermissionLevel, string> = {
+            [PermissionLevel.ANY]: '誰でも',
+            [PermissionLevel.STAFF]: 'スタッフ',
+            [PermissionLevel.ADMIN]: '管理者',
+            [PermissionLevel.OP]: 'サーバー管理者',
+        };
+
+        // ページ内のコマンドを追加
+        pageCommands.forEach(({ cmd, level }) => {
+            const cooldownText = cmd.cooldown ? ` (クールダウン: ${cmd.cooldown}秒)` : '';
+            const guildOnlyText = cmd.guildOnly ? ' 🏠' : '';
+            
+            embed.addFields({
+                name: `${levelEmoji[level]} \`/${cmd.data.name}\` ${guildOnlyText}`,
+                value: `${cmd.data.description}\n**必要権限:** ${levelName[level]}${cooldownText}`,
+                inline: false
+            });
+        });
+
+        // ページナビゲーション情報
+        if (totalPages > 1) {
+            const navInfo: string[] = [];
+            if (page > 1) navInfo.push(`⬅️ \`/help ${page - 1}\``);
+            if (page < totalPages) navInfo.push(`➡️ \`/help ${page + 1}\``);
+            
+            if (navInfo.length > 0) {
+                embed.addFields({
+                    name: '📖 ページ移動',
+                    value: navInfo.join(' | '),
+                    inline: false
+                });
+            }
+        }
+
+        await interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+};
+
+export default command;

--- a/src/commands/utility/ping-enhanced.ts
+++ b/src/commands/utility/ping-enhanced.ts
@@ -1,0 +1,48 @@
+import { PermissionLevel, DynamicCommandOptions, CommandBuilderCallback } from '../../types/enhanced-command.js';
+import { ChatInputCommandInteraction, EmbedBuilder, SlashCommandBuilder } from 'discord.js';
+
+const command: DynamicCommandOptions = {
+    name: 'ping',
+    description: 'Bot の応答速度を確認します',
+    permissionLevel: PermissionLevel.ANY,
+    
+    builder: ((eb: SlashCommandBuilder) => {
+        return eb.addBooleanOption(option =>
+            option
+                .setName('detailed')
+                .setDescription('詳細情報を表示')
+                .setRequired(false)
+        );
+    }) as CommandBuilderCallback,
+    
+    async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+        const detailed = interaction.options.getBoolean('detailed') ?? false;
+        const sent = await interaction.reply({ content: '計測中...', fetchReply: true });
+        const latency = sent.createdTimestamp - interaction.createdTimestamp;
+        const apiLatency = Math.round(interaction.client.ws.ping);
+
+        const embed = new EmbedBuilder()
+            .setColor('#00ff00')
+            .setTitle('🏓 Pong!')
+            .addFields(
+                { name: 'レイテンシ', value: `${latency}ms`, inline: true },
+                { name: 'API レイテンシ', value: `${apiLatency}ms`, inline: true }
+            );
+
+        if (detailed) {
+            const memoryUsage = Math.round(process.memoryUsage().heapUsed / 1024 / 1024);
+            const uptime = Math.floor(process.uptime() / 60);
+            
+            embed.addFields(
+                { name: 'メモリ使用量', value: `${memoryUsage} MB`, inline: true },
+                { name: '稼働時間', value: `${uptime} 分`, inline: true }
+            );
+        }
+
+        embed.setTimestamp();
+
+        await interaction.editReply({ content: '', embeds: [embed] });
+    }
+};
+
+export default command;

--- a/src/commands/utility/ping.ts
+++ b/src/commands/utility/ping.ts
@@ -1,0 +1,27 @@
+import { PermissionLevel, DynamicCommandOptions } from '../../types/enhanced-command.js';
+import { ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
+
+const command: DynamicCommandOptions = {
+    name: 'ping',
+    description: 'Bot の応答速度を確認します',
+    permissionLevel: PermissionLevel.ANY,
+    
+    async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+        const sent = await interaction.reply({ content: '計測中...', fetchReply: true });
+        const latency = sent.createdTimestamp - interaction.createdTimestamp;
+        const apiLatency = Math.round(interaction.client.ws.ping);
+
+        const embed = new EmbedBuilder()
+            .setColor('#00ff00')
+            .setTitle('🏓 Pong!')
+            .addFields(
+                { name: 'レイテンシ', value: `${latency}ms`, inline: true },
+                { name: 'API レイテンシ', value: `${apiLatency}ms`, inline: true }
+            )
+            .setTimestamp();
+
+        await interaction.editReply({ content: '', embeds: [embed] });
+    }
+};
+
+export default command;

--- a/src/commands/utility/userinfo.ts
+++ b/src/commands/utility/userinfo.ts
@@ -1,0 +1,60 @@
+import { PermissionLevel, DynamicCommandOptions, CommandBuilderCallback } from '../../types/enhanced-command.js';
+import { ChatInputCommandInteraction, EmbedBuilder, SlashCommandBuilder } from 'discord.js';
+
+const command: DynamicCommandOptions = {
+    name: 'userinfo',
+    description: 'ユーザー情報を表示します',
+    permissionLevel: PermissionLevel.ANY,
+    guildOnly: true,
+    
+    builder: ((eb: SlashCommandBuilder) => {
+        return eb.addUserOption(option =>
+            option
+                .setName('user')
+                .setDescription('情報を表示するユーザー')
+                .setRequired(false)
+        );
+    }) as CommandBuilderCallback,
+    
+    async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+        if (!interaction.guild) {
+            await interaction.reply({ 
+                content: 'このコマンドはサーバー内でのみ使用できます。', 
+                ephemeral: true 
+            });
+            return;
+        }
+
+        const targetUser = interaction.options.getUser('user') ?? interaction.user;
+        const member = interaction.guild.members.cache.get(targetUser.id);
+
+        if (!member) {
+            await interaction.reply({ 
+                content: 'ユーザー情報を取得できませんでした。', 
+                ephemeral: true 
+            });
+            return;
+        }
+
+        const accountCreatedTimestamp = Math.floor(targetUser.createdTimestamp / 1000);
+        const joinedTimestamp = member.joinedTimestamp ? Math.floor(member.joinedTimestamp / 1000) : 0;
+
+        const embed = new EmbedBuilder()
+            .setColor('#0099ff')
+            .setTitle(`👤 ${targetUser.tag} の情報`)
+            .setThumbnail(targetUser.displayAvatarURL({ size: 256 }))
+            .addFields(
+                { name: 'ユーザーID', value: targetUser.id, inline: true },
+                { name: 'ニックネーム', value: member.nickname ?? 'なし', inline: true },
+                { name: 'アカウント作成日', value: `<t:${accountCreatedTimestamp}:F>`, inline: false },
+                { name: 'サーバー参加日', value: joinedTimestamp ? `<t:${joinedTimestamp}:F>` : '不明', inline: false },
+                { name: 'ロール数', value: `${member.roles.cache.size - 1}`, inline: true },
+                { name: 'Bot', value: targetUser.bot ? 'はい' : 'いいえ', inline: true }
+            )
+            .setTimestamp();
+
+        await interaction.reply({ embeds: [embed] });
+    }
+};
+
+export default command;

--- a/src/core/BotClient.ts
+++ b/src/core/BotClient.ts
@@ -1,0 +1,299 @@
+import { Client, Collection, GatewayIntentBits, REST, Routes } from 'discord.js';
+import { SlashCommand } from '../types/command.js';
+import { database } from './Database.js';
+import { Logger } from '../utils/Logger.js';
+
+/**
+ * Discord APIコマンド型定義
+ */
+interface DiscordCommand {
+    id: string;
+    name: string;
+    description: string;
+    version?: string;
+}
+
+/**
+ * サーバー上限設定
+ */
+const MAX_GUILDS = 50;
+
+/**
+ * Discord Bot のクライアント管理クラス
+ */
+export class BotClient {
+    public client: Client;
+    public commands: Collection<string, SlashCommand>;
+    public token: string;
+    private rest: REST;
+
+    constructor(token: string) {
+        this.token = token;
+        this.commands = new Collection();
+        this.rest = new REST({ version: '10' }).setToken(token);
+
+        this.client = new Client({
+            intents: [
+                GatewayIntentBits.Guilds,
+                GatewayIntentBits.GuildMessages,
+                GatewayIntentBits.MessageContent,
+                GatewayIntentBits.GuildMembers,
+            ],
+        });
+
+        // サーバー参加イベント
+        this.setupGuildLimitHandler();
+    }
+
+    /**
+     * 登録されているコマンド一覧を取得
+     */
+    public getCommands(): Collection<string, SlashCommand> {
+        return this.commands;
+    }
+
+    /**
+     * サーバー上限チェックハンドラーを設定
+     */
+    private setupGuildLimitHandler(): void {
+        this.client.on('guildCreate', async (guild) => {
+            const guildCount = this.client.guilds.cache.size;
+            
+            Logger.info(`📥 新しいサーバーに参加: ${guild.name} (ID: ${guild.id})`);
+            Logger.info(`📊 現在のサーバー数: ${guildCount}/${MAX_GUILDS}`);
+
+            if (guildCount > MAX_GUILDS) {
+                Logger.warn(`⚠️ サーバー上限 (${MAX_GUILDS}) を超えました。サーバーから退出します: ${guild.name}`);
+                
+                try {
+                    // サーバーオーナーにメッセージを送信
+                    const owner = await guild.fetchOwner();
+                    await owner.send(
+                        `申し訳ございません。このBotは現在、最大${MAX_GUILDS}サーバーまでしかサポートしていません。\n` +
+                        `サーバー上限に達したため、「${guild.name}」から退出させていただきます。\n` +
+                        `ご理解のほどよろしくお願いいたします。`
+                    ).catch(() => {
+                        Logger.warn('サーバーオーナーへのDM送信に失敗しました');
+                    });
+                } catch (error) {
+                    Logger.error('サーバーオーナーの取得に失敗:', error);
+                }
+
+                // サーバーから退出
+                await guild.leave();
+                Logger.info(`✅ サーバーから退出しました: ${guild.name}`);
+            } else {
+                Logger.success(`✅ サーバーに参加しました: ${guild.name} (${guildCount}/${MAX_GUILDS})`);
+            }
+        });
+
+        this.client.on('guildDelete', (guild) => {
+            const guildCount = this.client.guilds.cache.size;
+            Logger.info(`📤 サーバーから退出: ${guild.name} (ID: ${guild.id})`);
+            Logger.info(`📊 現在のサーバー数: ${guildCount}/${MAX_GUILDS}`);
+        });
+    }
+
+    /**
+     * Bot を起動
+     */
+    async login(): Promise<void> {
+        try {
+            await this.client.login(this.token);
+            Logger.success('✅ Discord Bot にログインしました');
+        } catch (error) {
+            Logger.error('❌ ログインエラー:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Bot を停止
+     */
+    async destroy(): Promise<void> {
+        try {
+            this.client.destroy();
+            Logger.success('👋 Discord Bot を停止しました');
+        } catch (error) {
+            Logger.error('停止処理エラー:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * クライアントIDを取得（自動）
+     */
+    getClientId(): string {
+        if (!this.client.user) {
+            throw new Error('Bot がログインしていません');
+        }
+        return this.client.user.id;
+    }
+
+    /**
+     * コマンドを登録
+     * @param command スラッシュコマンド
+     */
+    registerCommand(command: SlashCommand): void {
+        this.commands.set(command.data.name, command);
+        Logger.info(`📝 コマンド登録: /${command.data.name}`);
+    }
+
+    /**
+     * 複数のコマンドを一括登録
+     * @param commands スラッシュコマンドの配列
+     */
+    registerCommands(commands: SlashCommand[]): void {
+        for (const command of commands) {
+            this.registerCommand(command);
+        }
+    }
+
+    /**
+     * すべてのギルドにコマンドをデプロイ（自動）
+     * 登録されていない古いコマンドを自動的にクリア
+     */
+    async deployCommandsToAllGuilds(): Promise<void> {
+        try {
+            const clientId = this.getClientId();
+            const commandData = Array.from(this.commands.values()).map(cmd => cmd.data.toJSON());
+            const guilds = this.client.guilds.cache;
+
+            Logger.info(`🚀 全サーバー (${guilds.size}個) にスラッシュコマンドをデプロイ中...`);
+            Logger.info(`📦 コマンド数: ${commandData.length}個`);
+
+            let successCount = 0;
+            let failCount = 0;
+
+            // ギルド固有のコマンドをデプロイ
+            for (const [guildId, guild] of guilds) {
+                try {
+                    // 古いコマンドをクリアして新しいコマンドをデプロイ
+                    await this.rest.put(
+                        Routes.applicationGuildCommands(clientId, guildId),
+                        { body: commandData }
+                    );
+                    successCount++;
+                    Logger.success(`  ✅ ${guild.name} (${guildId})`);
+                } catch (error) {
+                    failCount++;
+                    Logger.error(`  ❌ ${guild.name} (${guildId}):`, error);
+                }
+            }
+
+            // グローバルコマンドもクリア（未登録のものを削除）
+            try {
+                Logger.info('🌍 グローバルコマンドを同期中...');
+                await this.rest.put(
+                    Routes.applicationCommands(clientId),
+                    { body: [] } // グローバルコマンドは空にする（ギルド固有のみ使用）
+                );
+                Logger.success('✅ グローバルコマンドをクリアしました');
+            } catch (error) {
+                Logger.error('❌ グローバルコマンドのクリアに失敗:', error);
+            }
+
+            Logger.success(`✅ デプロイ完了: 成功 ${successCount} / 失敗 ${failCount}`);
+        } catch (error) {
+            Logger.error('❌ コマンドデプロイエラー:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * 未登録のコマンドを検出して削除（ギルドとグローバル両方）
+     */
+    async cleanupUnregisteredCommands(): Promise<void> {
+        try {
+            const clientId = this.getClientId();
+            const registeredCommandNames = new Set(
+                Array.from(this.commands.values()).map(cmd => cmd.data.name)
+            );
+
+            Logger.info('🧹 未登録コマンドのクリーンアップを開始...');
+
+            let totalDeleted = 0;
+
+            // 各ギルドの未登録コマンドをチェック
+            for (const [guildId, guild] of this.client.guilds.cache) {
+                try {
+                    const guildCommands = await this.rest.get(
+                        Routes.applicationGuildCommands(clientId, guildId)
+                    ) as DiscordCommand[];
+
+                    for (const cmd of guildCommands) {
+                        if (!registeredCommandNames.has(cmd.name)) {
+                            Logger.warn(`  🗑️ 削除: /${cmd.name} from ${guild.name}`);
+                            await this.rest.delete(
+                                Routes.applicationGuildCommand(clientId, guildId, cmd.id)
+                            );
+                            totalDeleted++;
+                        }
+                    }
+                } catch (error) {
+                    Logger.error(`  ❌ ${guild.name} のコマンドチェックに失敗:`, error);
+                }
+            }
+
+            // グローバルコマンドの未登録をチェック
+            try {
+                const globalCommands = await this.rest.get(
+                    Routes.applicationCommands(clientId)
+                ) as DiscordCommand[];
+
+                for (const cmd of globalCommands) {
+                    if (!registeredCommandNames.has(cmd.name)) {
+                        Logger.warn(`  🗑️ 削除: /${cmd.name} (グローバル)`);
+                        await this.rest.delete(
+                            Routes.applicationCommand(clientId, cmd.id)
+                        );
+                        totalDeleted++;
+                    }
+                }
+            } catch (error) {
+                Logger.error('  ❌ グローバルコマンドのチェックに失敗:', error);
+            }
+
+            if (totalDeleted > 0) {
+                Logger.success(`✅ ${totalDeleted} 個の未登録コマンドを削除しました`);
+            } else {
+                Logger.info('✅ 未登録コマンドはありませんでした');
+            }
+        } catch (error) {
+            Logger.error('❌ コマンドクリーンアップエラー:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * データベースを初期化
+     */
+    async initializeDatabase(): Promise<void> {
+        await database.initialize();
+    }
+
+    /**
+     * 現在のサーバー数を取得
+     */
+    getGuildCount(): number {
+        return this.client.guilds.cache.size;
+    }
+
+    /**
+     * サーバー上限を取得
+     */
+    getMaxGuilds(): number {
+        return MAX_GUILDS;
+    }
+
+    /**
+     * サーバーリストを取得
+     */
+    getGuildList(): Array<{ id: string; name: string; memberCount: number }> {
+        return Array.from(this.client.guilds.cache.values()).map(guild => ({
+            id: guild.id,
+            name: guild.name,
+            memberCount: guild.memberCount,
+        }));
+    }
+}

--- a/src/core/CommandLoader.ts
+++ b/src/core/CommandLoader.ts
@@ -1,0 +1,147 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { SlashCommand } from '../types/command.js';
+import { BotClient } from './BotClient.js';
+import { CommandRegistry } from './CommandRegistry.js';
+import { DynamicCommandOptions } from '../types/enhanced-command.js';
+import { Logger } from '../utils/Logger.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * コマンドローダー
+ * src/commands/ 配下のコマンドファイルを自動的に読み込む
+ * 新旧両方のコマンド形式をサポート
+ */
+export class CommandLoader {
+    private botClient: BotClient;
+    private registry: CommandRegistry;
+    private commandsDir: string;
+
+    constructor(botClient: BotClient, commandsDir?: string) {
+        this.botClient = botClient;
+        this.registry = new CommandRegistry(botClient);
+        this.commandsDir = commandsDir || path.join(path.dirname(__dirname), 'commands');
+    }
+
+    /**
+     * すべてのコマンドを読み込む
+     */
+    async loadAll(): Promise<void> {
+        try {
+            Logger.info(`📂 コマンドディレクトリ: ${this.commandsDir}`);
+            
+            const exists = await this.directoryExists(this.commandsDir);
+            if (!exists) {
+                Logger.warn(`⚠️ コマンドディレクトリが存在しません: ${this.commandsDir}`);
+                await fs.mkdir(this.commandsDir, { recursive: true });
+                Logger.info('📁 コマンドディレクトリを作成しました');
+                return;
+            }
+
+            const files = await this.getCommandFiles(this.commandsDir);
+            Logger.info(`📦 コマンドファイル数: ${files.length}`);
+
+            for (const file of files) {
+                await this.loadCommandFile(file);
+            }
+
+            Logger.success(`✅ ${this.botClient.commands.size} 個のコマンドを読み込みました`);
+        } catch (error) {
+            Logger.error('❌ コマンド読み込みエラー:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * コマンドファイルを再帰的に取得
+     */
+    private async getCommandFiles(dir: string): Promise<string[]> {
+        const files: string[] = [];
+        const entries = await fs.readdir(dir, { withFileTypes: true });
+
+        for (const entry of entries) {
+            const fullPath = path.join(dir, entry.name);
+            
+            if (entry.isDirectory()) {
+                // サブディレクトリを再帰的に探索
+                const subFiles = await this.getCommandFiles(fullPath);
+                files.push(...subFiles);
+            } else if (entry.isFile() && (entry.name.endsWith('.ts') || entry.name.endsWith('.js'))) {
+                // .ts または .js ファイルのみ
+                files.push(fullPath);
+            }
+        }
+
+        return files;
+    }
+
+    /**
+     * コマンドファイルを読み込んで登録
+     */
+    private async loadCommandFile(filePath: string): Promise<void> {
+        try {
+            // Windows パスを URL 形式に変換
+            const fileUrl = `file:///${filePath.replace(/\\/g, '/')}`;
+            const module = await import(fileUrl);
+            
+            const commandExport = module.default || module.command;
+
+            if (!commandExport) {
+                Logger.warn(`⚠️ 無効なコマンドファイル: ${filePath}`);
+                return;
+            }
+
+            // 新形式（DynamicCommandOptions）をチェック
+            if (this.isDynamicCommand(commandExport)) {
+                this.registry.registerCommand(commandExport);
+                return;
+            }
+
+            // 旧形式（SlashCommand）をチェック
+            if (this.isSlashCommand(commandExport)) {
+                this.botClient.registerCommand(commandExport);
+                return;
+            }
+
+            Logger.warn(`⚠️ 認識できないコマンド形式: ${filePath}`);
+        } catch (error) {
+            Logger.error(`❌ コマンドファイル読み込みエラー [${filePath}]:`, error);
+        }
+    }
+
+    /**
+     * 新形式（DynamicCommandOptions）かチェック
+     */
+    private isDynamicCommand(obj: any): obj is DynamicCommandOptions {
+        return obj.name && obj.description && typeof obj.execute === 'function';
+    }
+
+    /**
+     * 旧形式（SlashCommand）かチェック
+     */
+    private isSlashCommand(obj: any): obj is SlashCommand {
+        return obj.data && typeof obj.execute === 'function';
+    }
+
+    /**
+     * ディレクトリが存在するかチェック
+     */
+    private async directoryExists(dir: string): Promise<boolean> {
+        try {
+            await fs.access(dir);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * CommandRegistry を取得
+     */
+    getRegistry(): CommandRegistry {
+        return this.registry;
+    }
+}

--- a/src/core/CommandRegistry.ts
+++ b/src/core/CommandRegistry.ts
@@ -1,0 +1,168 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits, Collection } from 'discord.js';
+import { BotClient } from './BotClient.js';
+import { 
+    DynamicCommandOptions, 
+    EnhancedSlashCommand, 
+    PermissionLevel 
+} from '../types/enhanced-command.js';
+import { SlashCommand } from '../types/command.js';
+import { database } from './Database.js';
+import { Logger } from '../utils/Logger.js';
+
+/**
+ * コマンドレジストリ
+ * Builder パターンで動的にコマンドを登録
+ */
+export class CommandRegistry {
+    private static instance: CommandRegistry | null = null;
+    private botClient: BotClient;
+
+    constructor(botClient: BotClient) {
+        this.botClient = botClient;
+        CommandRegistry.instance = this;
+    }
+
+    /**
+     * シングルトンインスタンスを取得
+     */
+    static getInstance(): CommandRegistry {
+        if (!CommandRegistry.instance) {
+            throw new Error('CommandRegistry is not initialized');
+        }
+        return CommandRegistry.instance;
+    }
+
+    /**
+     * 登録されているコマンド一覧を取得
+     */
+    getCommands(): Collection<string, SlashCommand> {
+        return this.botClient.getCommands();
+    }
+
+    /**
+     * 動的にコマンドを登録
+     * @param options コマンドオプション
+     * 
+     * @example
+     * Core.registerCommand({
+     *   name: 'hello',
+     *   description: '挨拶します',
+     *   permissionLevel: PermissionLevel.ANY,
+     *   builder: (eb) => eb.addStringOption(opt => 
+     *     opt.setName('name').setDescription('名前').setRequired(true)
+     *   ),
+     *   execute: async (interaction) => {
+     *     const name = interaction.options.getString('name', true);
+     *     await interaction.reply(`こんにちは、${name}さん！`);
+     *   }
+     * });
+     */
+    registerCommand(options: DynamicCommandOptions): void {
+        try {
+            // SlashCommandBuilder を作成
+            let builder: SlashCommandBuilder | import('discord.js').SlashCommandOptionsOnlyBuilder = new SlashCommandBuilder()
+                .setName(options.name)
+                .setDescription(options.description);
+
+            // カスタムビルダーが指定されている場合は実行
+            if (options.builder) {
+                builder = options.builder(builder as SlashCommandBuilder);
+            }
+
+            // ギルド専用の場合は設定
+            if (options.guildOnly) {
+                builder.setDMPermission(false);
+            }
+
+            // 拡張コマンドオブジェクトを作成
+            const command: EnhancedSlashCommand = {
+                data: builder as SlashCommandBuilder,
+                execute: options.execute,
+                permissionLevel: options.permissionLevel || PermissionLevel.ANY,
+                cooldown: options.cooldown,
+                guildOnly: options.guildOnly,
+            };
+
+            // BotClient に登録
+            this.botClient.commands.set(options.name, command as any);
+            Logger.success(`✅ コマンド登録: /${options.name} (権限: ${command.permissionLevel})`);
+        } catch (error) {
+            Logger.error(`❌ コマンド登録エラー [${options.name}]:`, error);
+            throw error;
+        }
+    }
+
+    /**
+     * 複数のコマンドを一括登録
+     */
+    registerCommands(commandsArray: DynamicCommandOptions[]): void {
+        for (const options of commandsArray) {
+            this.registerCommand(options);
+        }
+    }
+
+    /**
+     * ユーザーの権限レベルをチェック
+     */
+    async checkPermission(
+        interaction: ChatInputCommandInteraction, 
+        requiredLevel: PermissionLevel
+    ): Promise<boolean> {
+        // ANY は誰でも実行可能
+        if (requiredLevel === PermissionLevel.ANY) {
+            return true;
+        }
+
+        // ギルド外では ANY のみ実行可能
+        if (!interaction.guild) {
+            return false;
+        }
+
+        const guildId = interaction.guild.id;
+        const userId = interaction.user.id;
+        const member = interaction.guild.members.cache.get(userId);
+
+        if (!member) return false;
+
+        // OP レベル: サーバー管理者権限を持つ
+        if (requiredLevel === PermissionLevel.OP) {
+            return member.permissions.has(PermissionFlagsBits.Administrator);
+        }
+
+        // ギルド設定を取得
+        const guildSettings = await database.get<any>(`guild_${guildId}`, {
+            adminRoles: [],
+            staffRoles: [],
+        });
+
+        // ADMIN レベル: 管理者ロールまたは OP
+        if (requiredLevel === PermissionLevel.ADMIN) {
+            const hasAdminRole = member.roles.cache.some(role => 
+                guildSettings.adminRoles.includes(role.id)
+            );
+            const isOp = member.permissions.has(PermissionFlagsBits.Administrator);
+            return hasAdminRole || isOp;
+        }
+
+        // STAFF レベル: スタッフロール、管理者ロール、または OP
+        if (requiredLevel === PermissionLevel.STAFF) {
+            const hasStaffRole = member.roles.cache.some(role => 
+                guildSettings.staffRoles.includes(role.id)
+            );
+            const hasAdminRole = member.roles.cache.some(role => 
+                guildSettings.adminRoles.includes(role.id)
+            );
+            const isOp = member.permissions.has(PermissionFlagsBits.Administrator);
+            return hasStaffRole || hasAdminRole || isOp;
+        }
+
+        return false;
+    }
+
+    /**
+     * コマンドの数を取得
+     */
+    getCommandCount(): number {
+        return this.botClient.commands.size;
+    }
+}

--- a/src/core/Database.ts
+++ b/src/core/Database.ts
@@ -1,0 +1,159 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * JSON ベースのデータベースシステム
+ * Data/ フォルダに各種設定を JSON ファイルとして保存・読み込みします
+ */
+export class Database {
+    private dataDir: string;
+    private cache: Map<string, any>;
+
+    constructor(dataDir?: string) {
+        // プロジェクトルートの Data フォルダをデフォルトとして使用
+        this.dataDir = dataDir || path.join(path.dirname(path.dirname(__dirname)), 'Data');
+        this.cache = new Map();
+    }
+
+    /**
+     * データベースを初期化（Data フォルダを作成）
+     */
+    async initialize(): Promise<void> {
+        try {
+            await fs.mkdir(this.dataDir, { recursive: true });
+            console.log(`📁 データベースディレクトリを初期化: ${this.dataDir}`);
+        } catch (error) {
+            console.error('データベースディレクトリの作成に失敗:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * データを保存
+     * @param key データのキー（ファイル名として使用）
+     * @param data 保存するデータ（JSON シリアライズ可能）
+     */
+    async set<T = any>(key: string, data: T): Promise<void> {
+        try {
+            const filePath = this.getFilePath(key);
+            const jsonData = JSON.stringify(data, null, 2);
+            await fs.writeFile(filePath, jsonData, 'utf-8');
+            this.cache.set(key, data);
+            console.log(`💾 データを保存: ${key}`);
+        } catch (error) {
+            console.error(`データ保存エラー [${key}]:`, error);
+            throw error;
+        }
+    }
+
+    /**
+     * データを取得
+     * @param key データのキー（ファイル名）
+     * @param defaultValue データが存在しない場合のデフォルト値
+     * @returns 保存されているデータまたはデフォルト値
+     */
+    async get<T = any>(key: string, defaultValue: T | null = null): Promise<T | null> {
+        try {
+            // キャッシュから取得を試みる
+            if (this.cache.has(key)) {
+                return this.cache.get(key);
+            }
+
+            const filePath = this.getFilePath(key);
+            const data = await fs.readFile(filePath, 'utf-8');
+            const parsed = JSON.parse(data) as T;
+            this.cache.set(key, parsed);
+            return parsed;
+        } catch (error) {
+            const nodeError = error as NodeJS.ErrnoException;
+            if (nodeError.code === 'ENOENT') {
+                // ファイルが存在しない場合はデフォルト値を返す
+                return defaultValue;
+            }
+            console.error(`データ読み込みエラー [${key}]:`, error);
+            throw error;
+        }
+    }
+
+    /**
+     * データが存在するかチェック
+     * @param key データのキー
+     * @returns 存在する場合 true
+     */
+    async has(key: string): Promise<boolean> {
+        try {
+            const filePath = this.getFilePath(key);
+            await fs.access(filePath);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * データを削除
+     * @param key データのキー
+     */
+    async delete(key: string): Promise<void> {
+        try {
+            const filePath = this.getFilePath(key);
+            await fs.unlink(filePath);
+            this.cache.delete(key);
+            console.log(`🗑️ データを削除: ${key}`);
+        } catch (error) {
+            const nodeError = error as NodeJS.ErrnoException;
+            if (nodeError.code !== 'ENOENT') {
+                console.error(`データ削除エラー [${key}]:`, error);
+                throw error;
+            }
+        }
+    }
+
+    /**
+     * すべてのキーを取得
+     * @returns 保存されているすべてのキー
+     */
+    async keys(): Promise<string[]> {
+        try {
+            const files = await fs.readdir(this.dataDir);
+            return files
+                .filter(file => file.endsWith('.json'))
+                .map(file => file.replace('.json', ''));
+        } catch (error) {
+            console.error('キー一覧の取得エラー:', error);
+            return [];
+        }
+    }
+
+    /**
+     * キャッシュをクリア
+     */
+    clearCache(): void {
+        this.cache.clear();
+        console.log('🧹 キャッシュをクリアしました');
+    }
+
+    /**
+     * ファイルパスを取得
+     * @param key データのキー
+     * @returns 完全なファイルパス
+     */
+    private getFilePath(key: string): string {
+        return path.join(this.dataDir, `${key}.json`);
+    }
+
+    /**
+     * データベースディレクトリのパスを取得
+     * @returns データベースディレクトリの絶対パス
+     */
+    getDataDir(): string {
+        return this.dataDir;
+    }
+}
+
+// シングルトンインスタンス
+export const database = new Database();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,472 +1,116 @@
-import { ActivityType, Client, Collection, Events, GatewayIntentBits, GuildMember, Interaction, Message, Partials, PresenceUpdateStatus, Team, User, VoiceState } from 'discord.js';
-import { EventEmitter } from 'events';
-import fsSync from 'fs';
-import fs from 'fs/promises';
-import inquirer from 'inquirer';
+﻿import fs from 'fs/promises';
 import path from 'path';
-import { loadStaticCommands } from './modules/static-loader';
-import { Command } from './types/command';
-const CONFIG_FILE_NAME = 'config.json';
-const CONFIG_FILE_PATH = path.join(process.cwd(), CONFIG_FILE_NAME);
-const PLUGINS_DIR = path.join(__dirname, 'plugins');
-export const PREFIX = '#';
-const EULA_TEXT = `
-========================= 利用規約 (EULA) =========================
-このツールは Discord Bot の管理を支援する目的で提供されます。
-開発者は、このツールの使用によって生じた、あるいは使用に関連して生じた
-いかなる種類の損害（データ損失、アカウント停止、その他の不利益を含むが
-これらに限定されない）についても、一切の責任を負いません。
-このツールの使用は、完全に自己の責任において行われるものとします。
-Discord の利用規約および開発者ポリシーを遵守してください。
-=================================================================
-`;
+import { fileURLToPath } from 'url';
+import { BotClient } from './core/BotClient.js';
+import { EventHandler } from './core/EventHandler.js';
+import { CommandLoader } from './core/CommandLoader.js';
+import { Logger } from './utils/Logger.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const CONFIG_FILE_PATH = path.join(path.dirname(__dirname), 'config.json');
+
 interface Config {
     token?: string;
-    eulaAgreed?: boolean;
-    globalAdmins?: string[];
-    guildAdmins?: Record<string, string[]>;
 }
-export const commands = new Collection<string, Command>();
-export let client: Client | null = null;
-export let currentConfig: Config = {};
-export const discordEventBroker = new EventEmitter();
-discordEventBroker.setMaxListeners(50);
-export interface CustomMessageEventPayload {
-    message: Message;
-    user: User;
-}
-export function isGlobalAdmin(userId: string): boolean {
-    return currentConfig?.globalAdmins?.includes(userId) ?? false;
-}
-export function isGuildAdmin(userId: string, guildId: string): boolean {
-    return currentConfig?.guildAdmins?.[guildId]?.includes(userId) ?? false;
-}
-export function isAdmin(userId: string, guildId?: string): boolean {
-    if (isGlobalAdmin(userId)) {
-        return true;
-    }
-    if (guildId && isGuildAdmin(userId, guildId)) {
-        return true;
-    }
-    return false;
-}
-export async function loadConfig(): Promise<Config | null> {
+
+let botClient: BotClient | null = null;
+
+/**
+ * 設定ファイルを読み込む
+ */
+async function loadConfig(): Promise<Config> {
     try {
         const data = await fs.readFile(CONFIG_FILE_PATH, 'utf-8');
-        const loadedData = JSON.parse(data) as Config;
-        if (!loadedData.guildAdmins) {
-            loadedData.guildAdmins = {};
-        }
-        if ((loadedData as any)['admins'] && !loadedData.globalAdmins) {
-            console.warn("古い設定形式('admins')を検出しました。'globalAdmins'に移行します。");
-            loadedData.globalAdmins = (loadedData as any)['admins'];
-            delete (loadedData as any).admins;
-        }
-        if (!loadedData.globalAdmins) {
-            loadedData.globalAdmins = [];
-        }
-        currentConfig = loadedData;
-        return currentConfig;
-    } catch (error: any) {
-        if (error.code === 'ENOENT') {
-            currentConfig = { globalAdmins: [], guildAdmins: {} };
-            return null;
-        }
-        console.error(`❌ 設定ファイル (${CONFIG_FILE_NAME}) の読み込みエラー:`, error.message);
-        currentConfig = { globalAdmins: [], guildAdmins: {} };
-        return null;
+        return JSON.parse(data);
+    } catch (error) {
+        Logger.error('設定ファイルの読み込みに失敗しました:', error);
+        return {};
     }
 }
-export async function saveConfig(configToSave: Config): Promise<boolean> {
-    try {
-        currentConfig = { ...configToSave };
-        if (!currentConfig.guildAdmins) currentConfig.guildAdmins = {};
-        if (!currentConfig.globalAdmins) currentConfig.globalAdmins = [];
-        await fs.writeFile(CONFIG_FILE_PATH, JSON.stringify(currentConfig, null, 2), 'utf-8');
-        console.log(`✔ 設定を ${CONFIG_FILE_NAME} に保存しました。`);
-        return true;
-    } catch (error: any) {
-        console.error(`❌ 設定ファイル (${CONFIG_FILE_NAME}) の保存エラー:`, error.message);
-        return false;
-    }
-}
-function isValidTokenFormat(token: string): boolean {
-    return /^[\w-]+\.[\w-]+\.[\w-]+$/.test(token);
-}
-async function promptForToken(): Promise<string | null> {
-    const { token } = await inquirer.prompt<{ token: string }>([
-        {
-            type: 'password', name: 'token', message: 'Discord Bot Token を入力してください:', mask: '*',
-            validate: (input: string) => {
-                if (!input) return 'トークンは必須です。';
-                if (!isValidTokenFormat(input)) return 'トークンの形式が正しくないようです。';
-                return true;
-            },
-        },
-    ]);
-    return token;
-}
-async function promptForEula(): Promise<boolean> {
-    console.log(EULA_TEXT);
-    const { agreed } = await inquirer.prompt<{ agreed: boolean }>([
-        { type: 'confirm', name: 'agreed', message: '上記の利用規約に同意し、自己責任で使用しますか？', default: false },
-    ]);
-    return agreed;
-}
-export function registerCommand(command: Command, source: string = '不明') {
-    if (command && command.name && typeof command.execute === 'function') {
-        if (commands.has(command.name)) {
-            console.log(`ℹ️ ${source}登録: コマンド名 "${command.name}" は既に登録済。上書きします。`);
-        }
-        commands.set(command.name, command);
-        if (command.aliases && command.aliases.length > 0) {
-            command.aliases.forEach(alias => {
-                if (commands.has(alias) && commands.get(alias)?.name !== command.name) {
-                    console.warn(`⚠️ ${source}登録: エイリアス "${alias}" (from ${command.name}) は既存のコマンド/エイリアス "${commands.get(alias)?.name}" と衝突しています。`);
-                } else if (!commands.has(alias)) {
-                    commands.set(alias, command);
-                }
-            });
-        }
-    } else {
-        console.warn(`⚠️ 無効なコマンドオブジェクトの登録試行 (ソース: ${source}):`, command);
-    }
-}
-async function loadCommands() {
-    const source = '動的';
-    console.log(`⚙️ ${source}コマンド/プラグイン読み込み中 (${PLUGINS_DIR})...`);
-    try {
-        if (!fsSync.existsSync(PLUGINS_DIR)) {
-            await fs.mkdir(PLUGINS_DIR, { recursive: true });
-            console.warn(`⚠️ ${source}プラグインディレクトリ (${PLUGINS_DIR}) が見つからなかったため作成しました。`);
-            return;
-        }
-        const pluginFiles = fsSync.readdirSync(PLUGINS_DIR)
-            .filter(file => file.endsWith('.js') || file.endsWith('.mjs'));
-        if (pluginFiles.length === 0) {
-            console.log(`ℹ️ 利用可能な${source}コマンド/プラグインファイル (.js/.mjs) が見つかりませんでした。`);
-            return;
-        }
-        console.log(`ℹ️ ${pluginFiles.length} 個の${source}プラグインファイルを検出。読み込み開始...`);
-        let loadedFileCount = 0;
-        let loadedCommandCount = 0;
-        for (const file of pluginFiles) {
-            const filePath = path.join(PLUGINS_DIR, file);
-            const isEsModule = file.endsWith('.mjs');
-            const moduleType = isEsModule ? 'ESM' : 'CJS';
-            try {
-                let moduleExports: any;
-                if (isEsModule) {
-                    const fileUrl = `file://${filePath.replace(/\\/g, '/')}`;
-                    moduleExports = await import(fileUrl + `?update=${Date.now()}`);
-                } else {
-                    delete require.cache[require.resolve(filePath)];
-                    moduleExports = require(filePath);
-                }
-                console.log(`   ✔ モジュール [${file}] (${moduleType}) 読み込み完了。`);
-                loadedFileCount++;
-                const command = moduleExports.default as Command || moduleExports.command as Command;
-                if (command && command.name && typeof command.execute === 'function') {
-                    registerCommand(command, `${source}(${file})`);
-                    loadedCommandCount++;
-                }
-            } catch (error: any) {
-                console.error(`❌ ファイル [${file}] (${moduleType}) の読み込み/処理エラー:`, error.message, error.stack);
-            }
-        }
-        console.log(`✔ ${loadedFileCount} 個の${source}プラグインファイルを読み込み、${loadedCommandCount} 個のコマンドを登録しました。`);
-    } catch (error: any) {
-        console.error(`❌ ${source}プラグイン読み込みプロセス全体でエラー:`, error.message);
-    }
-}
+
+/**
+ * メイン処理
+ */
 async function main() {
-    console.log('🔧 Discord 管理ツール起動...');
-    await loadConfig();
-    let token: string | undefined = currentConfig.token;
-    let tokenSource: 'config' | 'prompt' | 'none' = 'none';
-    if (token && isValidTokenFormat(token)) {
-        console.log(`ℹ️ 設定ファイルからトークンを読み込みました。`);
-        tokenSource = 'config';
-    } else {
-        if (token) { console.warn(`⚠️ 設定ファイルのトークン形式が不正です。再入力を求めます。`); }
-        else { console.log(`ℹ️ 設定ファイルが見つからないか、トークンがありません。`); }
-        const promptedToken = await promptForToken();
-        if (promptedToken) {
-            token = promptedToken;
-            currentConfig.token = token;
-            tokenSource = 'prompt';
-        } else {
-            console.error('❌ トークンを取得できませんでした。終了します。');
+    try {
+        Logger.info('🚀 Discord Bot を起動しています...');
+
+        // 設定ファイルを読み込む
+        const config = await loadConfig();
+
+        if (!config.token) {
+            Logger.error('❌ エラー: config.json に有効な token が設定されていません。');
             process.exit(1);
         }
-    }
-    if (!token) { console.error('❌ 有効なトークンがありません。終了します。'); process.exit(1); }
-    if (!currentConfig.eulaAgreed) {
-        const agreedToEula = await promptForEula();
-        if (!agreedToEula) {
-            console.log('ℹ️ 利用規約に同意されなかったため、ツールを終了します。');
-            process.exit(0);
-        }
-        console.log('✔ 利用規約に同意しました。');
-        currentConfig.eulaAgreed = true;
-        await saveConfig(currentConfig);
-    } else {
-        console.log('ℹ️ 利用規約には既に同意済みです。');
-    }
-    if (tokenSource === 'prompt' && currentConfig.token) {
-        const savedConfig = await loadConfig();
-        if (savedConfig?.token !== currentConfig.token) {
-            const { save } = await inquirer.prompt<{ save: boolean }>([
-                { type: 'confirm', name: 'save', message: `入力されたトークンを ${CONFIG_FILE_NAME} に保存しますか？`, default: true }
-            ]);
-            if (save) {
-                await saveConfig(currentConfig);
-            }
-        }
-    }
-    await loadStaticCommands();
-    const staticCommandCount = commands.filter((c, k) => c.name === k).size;
-    console.log(`ℹ️ 静的コマンド登録完了 (${staticCommandCount} 個)`);
-    await loadCommands();
-    const totalCommandCount = commands.filter((c, k) => c.name === k).size;
-    const totalAliasCount = commands.size;
-    console.log(`✔ 合計 ${totalCommandCount} 個のコマンド (${totalAliasCount - totalCommandCount} 個のエイリアス含む) が利用可能です。`);
-    console.log('⚙️ Discord への接続準備中...');
-    client = new Client({
-        intents: [
-            GatewayIntentBits.Guilds,
-            GatewayIntentBits.GuildMessages,
-            GatewayIntentBits.MessageContent,
-            GatewayIntentBits.GuildMembers,
-            GatewayIntentBits.GuildVoiceStates,
-        ],
-        partials: [Partials.Channel, Partials.Message, Partials.GuildMember, Partials.User],
-    });
-    client.once(Events.ClientReady, async (readyClient) => {
-        console.log(`✔ ${readyClient.user.tag} としてログインしました！`);
-        if (!currentConfig.globalAdmins || currentConfig.globalAdmins.length === 0) {
-            console.log('ℹ️ グローバル管理者リストが空です。Botオーナーを自動登録します...');
-            try {
-                if (!readyClient.application?.owner) await readyClient.application?.fetch();
-                const owner = readyClient.application?.owner;
-                if (owner instanceof User) {
-                    currentConfig.globalAdmins = [owner.id];
-                    await saveConfig(currentConfig);
-                    console.log(`✔ Botオーナー ${owner.tag} (${owner.id}) をグローバル管理者に自動登録しました。`);
-                } else if (owner instanceof Team) {
-                    const ownerIDs = owner.members.map(m => m.id);
-                    currentConfig.globalAdmins = ownerIDs;
-                    await saveConfig(currentConfig);
-                    console.log(`✔ Botオーナーチームのメンバー ${owner.members.size} 名をグローバル管理者に自動登録しました。`);
-                    owner.members.forEach(member => console.log(`   - ${member.user.tag} (${member.id})`));
-                } else {
-                    console.warn('⚠️ Botオーナー情報の取得に失敗しました。手動で管理者を登録してください (例: #admin global add <userID>)。');
-                    if (!currentConfig.globalAdmins) currentConfig.globalAdmins = [];
-                    if (!currentConfig.guildAdmins) currentConfig.guildAdmins = {};
-                    await saveConfig(currentConfig);
-                }
-            } catch (error: any) {
-                console.error('❌ Botオーナー情報の取得またはグローバル管理者登録中にエラー:', error.message);
-                if (!currentConfig.globalAdmins) currentConfig.globalAdmins = [];
-                if (!currentConfig.guildAdmins) currentConfig.guildAdmins = {};
-                await saveConfig(currentConfig);
-            }
-        } else {
-            console.log(`ℹ️ グローバル管理者(${currentConfig.globalAdmins?.length ?? 0}名)は設定済みです。`);
-        }
-        if (!currentConfig.guildAdmins) {
-            currentConfig.guildAdmins = {};
-            await saveConfig(currentConfig);
-        }
-        try {
-            readyClient.user.setPresence({
-                activities: [{ name: `サーバー監視中 | ${PREFIX}help`, type: ActivityType.Watching }],
-                status: PresenceUpdateStatus.Online,
-            });
-            console.log(`ℹ️ Botステータス設定完了。`);
-        } catch (error: any) {
-            console.error('❌ Botステータス設定エラー:', error.message);
-        }
-        discordEventBroker.emit(Events.ClientReady, readyClient);
-        console.log(`⌨️ イベントリスナー/コマンド待機中... (終了するには Ctrl+C)`);
-    });
-    const RATE_LIMIT_COUNT = 4;
-    const RATE_LIMIT_WINDOW_MS = 3 * 1000;
-    const RATE_LIMIT_DURATION_MS = 30 * 60 * 1000;
-    const userCommandTimestamps = new Map<string, number[]>();
-    const rateLimitedUsers = new Map<string, number>();
-    client.on(Events.MessageCreate, async (message: Message) => {
-        try {
-            if (client) {
-                discordEventBroker.emit(Events.MessageCreate, message, client);
-            } else {
-                console.warn(`⚠️ イベント転送スキップ (${Events.MessageCreate}): Client is not available.`);
-            }
-        } catch (e) {
-            console.error(`❌ イベント転送エラー (${Events.MessageCreate}):`, e);
-        }
-        if (message.author.bot || !message.guild || !message.content.startsWith(PREFIX)) {
-            return;
-        }
-        const userId = message.author.id;
-        const now = Date.now();
-        const expiryTimestamp = rateLimitedUsers.get(userId);
-        if (expiryTimestamp) {
-            if (now < expiryTimestamp) {
-                return;
-            } else {
-                rateLimitedUsers.delete(userId);
-                userCommandTimestamps.delete(userId);
-                console.log(`✅ レート制限解除: ${message.author.tag} (${userId})`);
-            }
-        }
-        const timestamps = userCommandTimestamps.get(userId) || [];
-        const recentTimestamps = timestamps.filter(ts => now - ts < RATE_LIMIT_WINDOW_MS);
-        if (recentTimestamps.length >= RATE_LIMIT_COUNT) {
-            const newExpiry = now + RATE_LIMIT_DURATION_MS;
-            rateLimitedUsers.set(userId, newExpiry);
-            userCommandTimestamps.delete(userId);
-            console.log(`🚫 レート制限適用: ${message.author.tag} (${userId}) - 解除時刻: ${new Date(newExpiry).toLocaleString()}`);
-            try {
-                await message.author.send(`⚠️ コマンドを短時間に送信しすぎたため、一時的に制限されました。約30分後に解除されます。`).catch(() => { });
-            } catch { }
-            return;
-        }
-        recentTimestamps.push(now);
-        userCommandTimestamps.set(userId, recentTimestamps);
-        const args = message.content.slice(PREFIX.length).trim().split(/ +/);
-        const commandNameInput = args.shift();
-        if (!commandNameInput) return;
-        const command = commands.get(commandNameInput);
-        if (!command) {
-            return;
-        }
-        if (command.admin) {
-            const guildId = message.guild.id;
-            const authorId = message.author.id;
-            if (!isAdmin(authorId, guildId)) {
-                console.log(`🚫 権限拒否: ${message.author.tag} (${authorId}) が管理者コマンド ${command.name} を試行 (Guild: ${message.guild.name} / ${guildId})`);
-                try { await message.reply('❌ このコマンドを実行する権限がありません。').catch(() => { }); } catch { }
-                return;
-            }
-        }
-        try {
-            if (!client) throw new Error("Client is unavailable for command execution");
-            await Promise.resolve(command.execute(client, message, args));
-        } catch (error: any) {
-            console.error(`❌ コマンド [${command.name}] 実行エラー (Input: ${commandNameInput}, User: ${message.author.tag}, Guild: ${message.guild.name}):`, error);
-            try { await message.reply('❌ コマンド実行中にエラーが発生しました。').catch(() => { }); } catch { }
-        }
-    });
-    client.on(Events.InteractionCreate, async (interaction: Interaction) => {
-        try { discordEventBroker.emit(Events.InteractionCreate, interaction); }
-        catch (e) { console.error(`❌ イベント転送エラー (${Events.InteractionCreate}):`, e) }
-        if (!interaction.isButton()) return;
-        const customId = interaction.customId;
-        const commandName = customId.split('_')[0];
-        if (!commandName) {
-            console.warn(`⚠️ Interaction customId (${customId}) にコマンド名プレフィックスがありません。`);
-            return;
-        }
-        const command = commands.get(commandName);
-        if (command && typeof command.handleInteraction === 'function') {
-            try {
-                await command.handleInteraction(interaction);
-            } catch (error) {
-                console.error(`❌ Interaction処理エラー (${commandName} / ID: ${customId}):`, error);
-                try {
-                    if (interaction.replied || interaction.deferred) {
-                        await interaction.followUp({ content: '🤕 Interaction処理中にエラーが発生しました。', ephemeral: true });
-                    } else {
-                        await interaction.reply({ content: '🤕 Interaction処理中にエラーが発生しました。', ephemeral: true });
-                    }
-                } catch (replyError) {
-                    console.error(`❌ Interactionエラーの返信失敗 (${commandName}):`, replyError);
-                }
-            }
-        } else {
-            console.warn(`⚠️ コマンド '${commandName}' に handleInteraction が未定義 (ID: ${customId})`);
-            try {
-                if (!interaction.replied && !interaction.deferred) {
-                    await interaction.reply({ content: '❓ このボタンは現在処理できません。', ephemeral: true });
-                }
-            } catch { }
-        }
-    });
-    client.on(Events.GuildMemberAdd, (member: GuildMember) => {
-        try { discordEventBroker.emit(Events.GuildMemberAdd, member); }
-        catch (e) { console.error(`❌ イベント転送エラー (${Events.GuildMemberAdd}):`, e) }
-    });
-    client.on(Events.VoiceStateUpdate, (oldState: VoiceState, newState: VoiceState) => {
-        try { discordEventBroker.emit(Events.VoiceStateUpdate, oldState, newState); }
-        catch (e) { console.error(`❌ イベント転送エラー (${Events.VoiceStateUpdate}):`, e) }
-    });
-    client.on(Events.Error, (error) => console.error('❌ Discord クライアントエラー:', error.message, error));
-    client.on(Events.Warn, (warning) => console.warn('⚠️ Discord クライアント警告:', warning));
-    console.log('🔌 Discord へログイン試行中...');
-    try {
-        await client.login(token);
-    } catch (error: any) {
-        console.error('❌ Discord ログイン失敗:', error.message);
-        if (error.code === 'TokenInvalid' || error.message.includes('TOKEN_INVALID')) {
-            console.error('   ➥ 提供されたトークンが無効です。Discord Developer Portal で確認してください。');
-            if (tokenSource === 'config') {
-                console.log(`   ℹ️ ${CONFIG_FILE_NAME} を確認または削除して再試行してください。`);
-                try {
-                    const { clear } = await inquirer.prompt<{ clear: boolean }>([
-                        { type: 'confirm', name: 'clear', message: `設定ファイル (${CONFIG_FILE_NAME}) から無効なトークンを削除しますか？`, default: false }
-                    ]);
-                    if (clear && currentConfig) {
-                        delete currentConfig.token;
-                        await saveConfig(currentConfig);
-                        console.log(`✔ ${CONFIG_FILE_NAME} からトークンを削除しました。`);
-                    }
-                } catch (promptError) {
-                    console.error('トークン削除確認中にエラー:', promptError);
-                }
-            }
-        } else if (error.code === 'DisallowedIntents' || error.message.includes('Privileged intent')) {
-            console.error('   ➥ Botに必要なインテントが Discord Developer Portal で有効になっていません。');
-            const requiredIntents = Object.keys(GatewayIntentBits)
-                .filter(k => client?.options.intents.has(GatewayIntentBits[k as keyof typeof GatewayIntentBits]))
-                .join(', ');
-            console.error(`   ➥ 現在有効化が必要なインテント: ${requiredIntents}。これらを Developer Portal で有効にしてください。`);
-        }
+
+        // Bot クライアントを初期化
+        botClient = new BotClient(config.token);
+
+        // Bot にログイン（クライアントIDを取得するため）
+        await botClient.login();
+
+        // データベースを初期化
+        await botClient.initializeDatabase();
+
+        Logger.info(`📊 現在のサーバー数: ${botClient.getGuildCount()}/${botClient.getMaxGuilds()}`);
+
+        // コマンドローダーを初期化
+        const commandLoader = new CommandLoader(botClient);
+        await commandLoader.loadAll();
+
+        // イベントハンドラーを登録
+        const eventHandler = new EventHandler(botClient);
+        eventHandler.setRegistry(commandLoader.getRegistry());
+        eventHandler.registerAll();
+
+        // すべてのサーバーにコマンドをデプロイ
+        Logger.info('🚀 全サーバーにコマンドをデプロイします...');
+        await botClient.deployCommandsToAllGuilds();
+
+        // 未登録コマンドのクリーンアップ
+        Logger.info('🧹 未登録コマンドのクリーンアップを実行します...');
+        await botClient.cleanupUnregisteredCommands();
+        
+        Logger.success('✅ Bot が正常に起動しました！');
+        Logger.info('💡 新しいサーバーに追加すると、自動的にコマンドがデプロイされます。');
+        Logger.info(`⚠️ サーバー上限: ${botClient.getMaxGuilds()} (現在: ${botClient.getGuildCount()})`);
+    } catch (error) {
+        Logger.error('起動エラー:', error);
         process.exit(1);
     }
 }
-async function handleExit(signal: NodeJS.Signals | string) {
-    console.log(`\nℹ️ ${signal} シグナル受信。終了処理を開始します...`);
-    if (client) {
-        console.log('🔌 Discord からログアウトしています...');
-        try {
-            await client.destroy();
-            console.log('✔ Discord から正常にログアウトしました。');
-        } catch (error: any) {
-            console.error('❌ Discord ログアウト中にエラーが発生:', error.message);
-        } finally {
-            client = null;
-        }
-    } else {
-        console.log('ℹ️ Discord クライアントは初期化されていないか、既に破棄されています。');
-    }
-    console.log('👋 ツールを終了します。');
-    process.exit(0);
-}
-process.on('SIGINT', () => handleExit('SIGINT'));
-process.on('SIGTERM', () => handleExit('SIGTERM'));
-process.on('uncaughtException', async (error, origin) => {
-    console.error(`💥 キャッチされない例外が発生しました (Origin: ${origin}):`, error);
-    try {
-        await handleExit('uncaughtException');
-    } catch { } finally {
-        process.exit(1);
-    }
+
+/**
+ * エラーハンドラー
+ */
+process.on('unhandledRejection', (error) => {
+    Logger.error('未処理の Promise 拒否:', error);
 });
-process.on('unhandledRejection', async (reason) => {
-    console.error('💥 ハンドルされない Promise 拒否:', reason);
-});
-main().catch((error) => {
-    console.error('💥 main 関数で致命的なエラーが発生しました:', error);
+
+process.on('uncaughtException', (error) => {
+    Logger.error('未処理の例外:', error);
     process.exit(1);
 });
+
+/**
+ * 終了処理
+ */
+process.on('SIGINT', async () => {
+    Logger.info('\n🛑 終了処理を開始します...');
+    if (botClient) {
+        await botClient.destroy();
+    }
+    process.exit(0);
+});
+
+process.on('SIGTERM', async () => {
+    Logger.info('\n🛑 終了処理を開始します...');
+    if (botClient) {
+        await botClient.destroy();
+    }
+    process.exit(0);
+});
+
+// アプリケーションを起動
+main();

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -1,11 +1,32 @@
-import { Message, Client, Interaction } from 'discord.js';
+﻿import { 
+    Message, 
+    Client, 
+    ChatInputCommandInteraction,
+    SlashCommandBuilder,
+    SlashCommandSubcommandsOnlyBuilder
+} from 'discord.js';
+import { PermissionLevel } from './enhanced-command.js';
 
+/**
+ * レガシーメッセージコマンドの型定義（後方互換性のため残す）
+ */
 export interface Command {
     name: string;
     description: string;
     aliases?: string[];
     usage?: string;
-    admin?: boolean; 
+    admin?: boolean;
     execute: (client: Client, message: Message, args: string[]) => Promise<void> | void;
-    handleInteraction?: (interaction: Interaction) => Promise<void>;
+}
+
+/**
+ * スラッシュコマンドの型定義
+ */
+export interface SlashCommand {
+    data: SlashCommandBuilder | SlashCommandSubcommandsOnlyBuilder | Omit<SlashCommandBuilder, "addSubcommand" | "addSubcommandGroup">;
+    execute: (interaction: ChatInputCommandInteraction) => Promise<void>;
+    cooldown?: number; // クールダウン時間（秒）
+    permissions?: bigint[]; // 必要な権限
+    guildOnly?: boolean; // ギルド専用コマンドか
+    permissionLevel?: PermissionLevel; // 権限レベル（動的登録コマンド用）
 }

--- a/src/types/discord.ts
+++ b/src/types/discord.ts
@@ -1,0 +1,196 @@
+import { 
+    ChatInputCommandInteraction, 
+    SlashCommandBuilder,
+    Client,
+    Guild,
+    GuildMember,
+    User,
+    Role,
+    Collection,
+    Message,
+    ButtonInteraction,
+    SelectMenuInteraction,
+    ModalSubmitInteraction,
+    AutocompleteInteraction
+} from 'discord.js';
+
+/**
+ * Discord.js の型定義を再エクスポート
+ */
+export type {
+    ChatInputCommandInteraction,
+    SlashCommandBuilder,
+    Client,
+    Guild,
+    GuildMember,
+    User,
+    Role,
+    Collection,
+    Message,
+    ButtonInteraction,
+    SelectMenuInteraction,
+    ModalSubmitInteraction,
+    AutocompleteInteraction
+};
+
+/**
+ * Bot クライアントの拡張型
+ */
+export interface ExtendedClient extends Client {
+    commands: Collection<string, any>;
+}
+
+/**
+ * ギルド設定の型定義
+ */
+export interface GuildSettings {
+    guildId: string;
+    adminRoles: string[];
+    staffRoles: string[];
+    plugins: Record<string, boolean>;
+    prefix?: string;
+    language?: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+/**
+ * データベースのキー・バリュー型
+ */
+export interface DatabaseEntry<T = any> {
+    value: T;
+    savedAt: string;
+    savedBy?: string;
+}
+
+/**
+ * サーバー情報の型
+ */
+export interface GuildInfo {
+    id: string;
+    name: string;
+    memberCount: number;
+    ownerId: string;
+    createdAt: Date;
+}
+
+/**
+ * コマンド実行コンテキスト
+ */
+export interface CommandContext {
+    interaction: ChatInputCommandInteraction;
+    guild: Guild | null;
+    member: GuildMember | null;
+    user: User;
+    client: ExtendedClient;
+}
+
+/**
+ * エラーレスポンスの型
+ */
+export interface ErrorResponse {
+    success: false;
+    error: string;
+    code?: string;
+    details?: Record<string, unknown>;
+}
+
+/**
+ * 成功レスポンスの型
+ */
+export interface SuccessResponse<T = any> {
+    success: true;
+    data: T;
+    message?: string;
+}
+
+/**
+ * API レスポンスの型（Union 型）
+ */
+export type ApiResponse<T = any> = SuccessResponse<T> | ErrorResponse;
+
+/**
+ * 権限チェック結果
+ */
+export interface PermissionCheckResult {
+    hasPermission: boolean;
+    reason?: string;
+    requiredLevel: string;
+    userLevel: string;
+}
+
+/**
+ * コマンド統計情報
+ */
+export interface CommandStats {
+    commandName: string;
+    executionCount: number;
+    lastExecuted: string;
+    averageExecutionTime: number;
+    errorCount: number;
+}
+
+/**
+ * プラグイン情報
+ */
+export interface PluginInfo {
+    id: string;
+    name: string;
+    version: string;
+    description: string;
+    author: string;
+    enabled: boolean;
+    dependencies?: string[];
+}
+
+/**
+ * 認証トークンの型
+ */
+export interface AuthToken {
+    token: string;
+    userId: string;
+    guildId: string;
+    expiresAt: number;
+    permissions: string[];
+}
+
+/**
+ * ユーザー情報の型
+ */
+export interface UserInfo {
+    id: string;
+    username: string;
+    discriminator: string;
+    avatar: string | null;
+    bot: boolean;
+    createdAt: Date;
+}
+
+/**
+ * ロール情報の型
+ */
+export interface RoleInfo {
+    id: string;
+    name: string;
+    color: number;
+    position: number;
+    permissions: string;
+    mentionable: boolean;
+}
+
+/**
+ * コマンドオプションの値の型
+ */
+export type CommandOptionValue = string | number | boolean | User | GuildMember | Role | null;
+
+/**
+ * イベントハンドラーの型
+ */
+export type EventHandler<T = any> = (data: T) => Promise<void> | void;
+
+/**
+ * コマンドミドルウェアの型
+ */
+export type CommandMiddleware = (
+    interaction: ChatInputCommandInteraction
+) => Promise<boolean> | boolean;

--- a/src/types/enhanced-command.ts
+++ b/src/types/enhanced-command.ts
@@ -1,0 +1,53 @@
+import { 
+    ChatInputCommandInteraction, 
+    SlashCommandBuilder,
+    SlashCommandOptionsOnlyBuilder 
+} from 'discord.js';
+
+/**
+ * 権限レベル
+ */
+export enum PermissionLevel {
+    ANY = 'any',           // 誰でも実行可能
+    STAFF = 'staff',       // スタッフロール（サーバー設定で指定）
+    ADMIN = 'admin',       // 管理者ロール（サーバー設定で指定）
+    OP = 'op',             // サーバー管理者権限を持つユーザー
+}
+
+/**
+ * コマンドビルダーのコールバック型
+ * SlashCommandBuilder または SlashCommandOptionsOnlyBuilder を返す
+ */
+export type CommandBuilderCallback = (
+    builder: SlashCommandBuilder
+) => SlashCommandBuilder | SlashCommandOptionsOnlyBuilder;
+
+/**
+ * コマンド実行コールバック型（厳密な型定義）
+ */
+export type CommandExecuteCallback = (interaction: ChatInputCommandInteraction) => Promise<void>;
+
+/**
+ * 動的登録用のコマンドオプション
+ */
+export interface DynamicCommandOptions {
+    name: string;
+    description: string;
+    permissionLevel?: PermissionLevel;
+    cooldown?: number;
+    guildOnly?: boolean;
+    builder?: CommandBuilderCallback;
+    execute: CommandExecuteCallback;
+}
+
+/**
+ * 拡張されたスラッシュコマンドインターフェース
+ */
+export interface EnhancedSlashCommand {
+    data: SlashCommandBuilder;
+    execute: CommandExecuteCallback;
+    permissionLevel: PermissionLevel;
+    cooldown?: number;
+    guildOnly?: boolean;
+    category?: string;
+}

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,0 +1,62 @@
+/**
+ * ロガークラス
+ * コンソールに色付きログを出力
+ */
+export class Logger {
+    private static colors = {
+        reset: '\x1b[0m',
+        bright: '\x1b[1m',
+        red: '\x1b[31m',
+        green: '\x1b[32m',
+        yellow: '\x1b[33m',
+        blue: '\x1b[34m',
+        magenta: '\x1b[35m',
+        cyan: '\x1b[36m',
+        white: '\x1b[37m',
+    };
+
+    /**
+     * 情報ログ
+     */
+    static info(message: string, ...args: any[]): void {
+        console.log(`${this.colors.cyan}[INFO]${this.colors.reset} ${message}`, ...args);
+    }
+
+    /**
+     * 成功ログ
+     */
+    static success(message: string, ...args: any[]): void {
+        console.log(`${this.colors.green}[SUCCESS]${this.colors.reset} ${message}`, ...args);
+    }
+
+    /**
+     * 警告ログ
+     */
+    static warn(message: string, ...args: any[]): void {
+        console.warn(`${this.colors.yellow}[WARN]${this.colors.reset} ${message}`, ...args);
+    }
+
+    /**
+     * エラーログ
+     */
+    static error(message: string, ...args: any[]): void {
+        console.error(`${this.colors.red}[ERROR]${this.colors.reset} ${message}`, ...args);
+    }
+
+    /**
+     * デバッグログ
+     */
+    static debug(message: string, ...args: any[]): void {
+        if (process.env.DEBUG === 'true') {
+            console.log(`${this.colors.magenta}[DEBUG]${this.colors.reset} ${message}`, ...args);
+        }
+    }
+
+    /**
+     * コマンド実行ログ
+     */
+    static command(commandName: string, userId: string, guildId?: string): void {
+        const location = guildId ? `Guild: ${guildId}` : 'DM';
+        console.log(`${this.colors.blue}[COMMAND]${this.colors.reset} /${commandName} | User: ${userId} | ${location}`);
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "compilerOptions": {
         "target": "ESNext",
         "module": "ESNext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "lib": [
             "ESNext",
             "DOM"


### PR DESCRIPTION
Replaced the large monolithic src/index.ts with an ESM-style entry that delegates startup to core modules (BotClient, EventHandler, CommandLoader, Logger). Simplified config shape and load path (config.json moved to repo root), removed legacy EULA/interactive prompts and global discord.js state, and updated .gitignore to ignore config.json. This improves modularity, ESM compatibility, and testability while clarifying the startup flow.